### PR TITLE
DO NOT DELETE - WEB-2963 - Adding callback style for createWriteStream

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -1124,79 +1124,86 @@ FtpConnection.prototype._STOR_usingCreateWriteStream = function(filename, initia
   var self = this;
 
   var wStreamFlags = {flags: flag || 'w', mode: 0644};
-  var storeStream = self.fs.createWriteStream(pathModule.join(self.root, filename), wStreamFlags);
-  var notErr = true;
-  // Adding for event metadata for file upload (STOR)
-  var startTime = new Date();
-
-  if (initialBuffers) {
-    //todo: handle back-pressure
-    initialBuffers.forEach(function(b) {
-      storeStream.write(b);
-    });
+  self.fs.createWriteStream(pathModule.join(self.root, filename), wStreamFlags, function(err, storeStream) {
+  if (err) {
+    self._logIf(LOG.ERROR, 'Error deleting file: ' + filename + ', ' + err);
+    // write error to socket
+    self.respond('550 Permission denied');
+    return;
   }
+    var notErr = true;
+    // Adding for event metadata for file upload (STOR)
+    var startTime = new Date();
 
-  self._whenDataReady(handleUpload);
-
-  storeStream.on('open', function() {
-    self._logIf(LOG.DEBUG, 'File opened/created: ' + filename);
-    self._logIf(LOG.DEBUG, 'Told client ok to send file data');
-    // Adding event emitter for upload start time
-    self.emit('file:stor', 'open', {
-      user: self.username,
-      file: filename,
-      time: startTime,
-    });
-
-    self.respond('150 Ok to send data');
-  });
-
-  storeStream.on('error', function() {
-    self.emit('file:stor', 'error', {
-      user: self.username,
-      file: filename,
-      /** @deprecated filesize is deprecated, use bytesRead/bytesWritten instead */
-      filesize: 0,
-      bytesWritten: storeStream.bytesWritten,
-      sTime: startTime,
-      eTime: new Date(),
-      duration: new Date() - startTime,
-      errorState: !notErr,
-    });
-    storeStream.end();
-    notErr = false;
-    if (self.dataSocket) {
-      self._closeSocket(self.dataSocket, true);
+    if (initialBuffers) {
+      //todo: handle back-pressure
+      initialBuffers.forEach(function(b) {
+        storeStream.write(b);
+      });
     }
-    self.respond('426 Connection closed; transfer aborted');
-  });
 
-  storeStream.on('finish', function() {
-    // Adding event emitter for completed upload.
-    self.emit('file:stor', 'close', {
-      user: self.username,
-      file: filename,
-      /** @deprecated filesize is deprecated, use bytesRead/bytesWritten instead */
-      filesize: 0,
-      bytesWritten: storeStream.bytesWritten,
-      sTime: startTime,
-      eTime: new Date(),
-      duration: new Date() - startTime,
-      errorState: !notErr,
+    self._whenDataReady(handleUpload);
+
+    storeStream.on('open', function() {
+      self._logIf(LOG.DEBUG, 'File opened/created: ' + filename);
+      self._logIf(LOG.DEBUG, 'Told client ok to send file data');
+      // Adding event emitter for upload start time
+      self.emit('file:stor', 'open', {
+        user: self.username,
+        file: filename,
+        time: startTime,
+      });
+
+      self.respond('150 Ok to send data');
     });
-    notErr ? self.respond('226 Closing data connection') : true;
-    if (self.dataSocket) {
-      self._closeSocket(self.dataSocket);
-    }
-  });
 
-  function handleUpload(dataSocket) {
-    dataSocket.pipe(storeStream);
-    dataSocket.on('error', function(err) {
+    storeStream.on('error', function() {
+      self.emit('file:stor', 'error', {
+        user: self.username,
+        file: filename,
+        /** @deprecated filesize is deprecated, use bytesRead/bytesWritten instead */
+        filesize: 0,
+        bytesWritten: storeStream.bytesWritten,
+        sTime: startTime,
+        eTime: new Date(),
+        duration: new Date() - startTime,
+        errorState: !notErr,
+      });
+      storeStream.end();
       notErr = false;
-      self._logIf(LOG.ERROR, 'Data connection error: ' + util.inspect(err));
+      if (self.dataSocket) {
+        self._closeSocket(self.dataSocket, true);
+      }
+      self.respond('426 Connection closed; transfer aborted');
     });
-  }
+
+    storeStream.on('finish', function() {
+      // Adding event emitter for completed upload.
+      self.emit('file:stor', 'close', {
+        user: self.username,
+        file: filename,
+        /** @deprecated filesize is deprecated, use bytesRead/bytesWritten instead */
+        filesize: 0,
+        bytesWritten: storeStream.bytesWritten,
+        sTime: startTime,
+        eTime: new Date(),
+        duration: new Date() - startTime,
+        errorState: !notErr,
+      });
+      notErr ? self.respond('226 Closing data connection') : true;
+      if (self.dataSocket) {
+        self._closeSocket(self.dataSocket);
+      }
+    });
+
+    function handleUpload(dataSocket) {
+      dataSocket.pipe(storeStream);
+      dataSocket.on('error', function(err) {
+        notErr = false;
+        self._logIf(LOG.ERROR, 'Data connection error: ' + util.inspect(err));
+      });
+    }
+  });
 };
 
 FtpConnection.prototype._STOR_usingWriteFile = function(filename, flag) {


### PR DESCRIPTION
Switching up createWriteStream to use a callback to allow erroring before uploading.